### PR TITLE
Add Solution and Tests for LeetCode Problem 844 - Backspace String Compare

### DIFF
--- a/backspace-string-compare/Cargo.toml
+++ b/backspace-string-compare/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "backspace-string-compare"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/backspace-string-compare/src/lib.rs
+++ b/backspace-string-compare/src/lib.rs
@@ -1,0 +1,59 @@
+use std::collections::VecDeque;
+
+struct Solution {}
+impl Solution {
+    pub fn backspace_compare(s: String, t: String) -> bool {
+        let mut s_stack = VecDeque::new();
+        let mut t_stack = VecDeque::new();
+
+        s.chars().for_each(|letter| {
+            if letter == '#' {
+                s_stack.pop_front();
+            } else {
+                s_stack.push_front(letter);
+            }
+        });
+        t.chars().for_each(|letter| {
+            if letter == '#' {
+                t_stack.pop_front();
+            } else {
+                t_stack.push_front(letter);
+            }
+        });
+
+        s_stack == t_stack
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Solution;
+
+    #[test]
+    fn test_backspace_compare() {
+        assert_eq!(
+            Solution::backspace_compare(String::from("ab#c"), String::from("ad#c")),
+            true
+        );
+        assert_eq!(
+            Solution::backspace_compare(String::from("ab##"), String::from("c#d#")),
+            true
+        );
+        assert_eq!(
+            Solution::backspace_compare(String::from("a#c"), String::from("b")),
+            false
+        );
+        assert_eq!(
+            Solution::backspace_compare(String::from("xy#z"), String::from("xzz#")),
+            true
+        );
+        assert_eq!(
+            Solution::backspace_compare(String::from("###a"), String::from("a")),
+            true
+        );
+        assert_eq!(
+            Solution::backspace_compare(String::from("###"), String::from("")),
+            true
+        );
+    }
+}

--- a/backspace-string-compare/src/lib.rs
+++ b/backspace-string-compare/src/lib.rs
@@ -2,24 +2,20 @@ use std::collections::VecDeque;
 
 struct Solution {}
 impl Solution {
+    fn eval_string(input_string: String) -> VecDeque<char> {
+        let mut stack = VecDeque::new();
+        input_string.chars().for_each(|letter| {
+            if letter == '#' {
+                stack.pop_front();
+            } else {
+                stack.push_front(letter);
+            }
+        });
+        stack
+    }
     pub fn backspace_compare(s: String, t: String) -> bool {
-        let mut s_stack = VecDeque::new();
-        let mut t_stack = VecDeque::new();
-
-        s.chars().for_each(|letter| {
-            if letter == '#' {
-                s_stack.pop_front();
-            } else {
-                s_stack.push_front(letter);
-            }
-        });
-        t.chars().for_each(|letter| {
-            if letter == '#' {
-                t_stack.pop_front();
-            } else {
-                t_stack.push_front(letter);
-            }
-        });
+        let s_stack = Solution::eval_string(s);
+        let t_stack = Solution::eval_string(t);
 
         s_stack == t_stack
     }


### PR DESCRIPTION

## Problem Description
The problem, [Backspace String Compare](https://leetcode.com/problems/backspace-string-compare/), requires us to compare two strings after simulating a backspace operation. A '#' character represents a backspace operation. The goal is to determine if the two strings are equal after applying the backspace operations.

## Solution
In the provided solution, we use two `VecDeque` data structures, one for each input string. We iterate through the characters in each input string and perform the following steps:

1. If the current character is not '#', we push it to the front of the respective `VecDeque`.
2. If the current character is '#', we perform a `pop_front()` operation on the respective `VecDeque` to simulate the backspace operation.

Finally, we compare the two `VecDeque` structures to determine if they are equal.

## Tests
The solution includes a test module with six test cases, covering the examples from the problem statement and some additional edge cases. These tests help ensure that the `backspace_compare` function works correctly.
