### PR TITLE
Optimize backspace string compare implementation

### DIFF
--- a/backspace-string-compare/src/lib.rs
+++ b/backspace-string-compare/src/lib.rs
@@ -1,21 +1,29 @@
-use std::collections::VecDeque;
-
 struct Solution {}
 impl Solution {
-    fn eval_string(input_string: String) -> VecDeque<char> {
-        let mut stack = VecDeque::new();
-        input_string.chars().for_each(|letter| {
-            if letter == '#' {
-                stack.pop_front();
-            } else {
-                stack.push_front(letter);
+    fn eval_string(input_string: &str) -> (u32, u32) {
+        let mut evaluated_num = 0;
+        let mut backspace = 0;
+        let mut idx: u32 = 1;
+        let mut count_letters = 0;
+        input_string.chars().rev().for_each(|letter| match letter {
+            '#' => backspace += 1,
+            _ if backspace > 0 => backspace -= 1,
+            _ => {
+                let letter_num = letter as u32 - 97;
+                let current_num = letter_num * 10u32.pow(idx);
+                evaluated_num += current_num;
+                idx += 1;
+                if idx >= 8 {
+                    idx = 1;
+                }
+                count_letters += 1;
             }
         });
-        stack
+        (count_letters, evaluated_num)
     }
     pub fn backspace_compare(s: String, t: String) -> bool {
-        let s_stack = Solution::eval_string(s);
-        let t_stack = Solution::eval_string(t);
+        let s_stack = Solution::eval_string(s.as_str());
+        let t_stack = Solution::eval_string(t.as_str());
 
         s_stack == t_stack
     }
@@ -50,6 +58,30 @@ mod tests {
         assert_eq!(
             Solution::backspace_compare(String::from("###"), String::from("")),
             true
+        );
+        assert_eq!(
+            Solution::backspace_compare(String::from("abc#"), String::from("bca#")),
+            false
+        );
+        assert_eq!(
+            Solution::backspace_compare(String::from("abc#"), String::from("bac#")),
+            false
+        );
+        assert_eq!(
+            Solution::backspace_compare(String::from("ba"), String::from("ac")),
+            false
+        );
+        assert_eq!(
+            Solution::backspace_compare(String::from("aaa###a"), String::from("aaaa###a")),
+            false
+        );
+        let s =
+        "tdkag#neumi#wkds####i#qoqk####mrrlcnsjeiq##########qm#sxl##qrupdvndi######telzybxummoodfslfrnuaqhixabuheg#####################ayvlbyvjmjpekofgojkjvse#";
+        let t =
+        "tdkag#neumi#wkds####i#qoqk####mrrlcnsjeiq##########qm#sxl##qrupdvndi######telz#ybxummoodfslfrnuaqhixabuheg#####################ayvlbyvjmjpekofgojkjvse#";
+        assert_eq!(
+            Solution::backspace_compare(s.to_string(), t.to_string()),
+            false
         );
     }
 }


### PR DESCRIPTION
This commit optimizes the backspace string compare implementation by using a single pass and calculating string values. This change reduces the complexity of the code and improves performance. The previous implementation used a stack to store characters and pop them when a backspace was encountered. The new implementation calculates the effective string value while traversing the string in reverse order and taking backspaces into account.
