### PR TITLE
Implement Queue using Stacks

### DIFF
--- a/implement-queue-using-stacks/Cargo.toml
+++ b/implement-queue-using-stacks/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "implement-queue-using-stacks"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/implement-queue-using-stacks/src/lib.rs
+++ b/implement-queue-using-stacks/src/lib.rs
@@ -1,7 +1,6 @@
-use std::collections::VecDeque;
-
 struct MyQueue {
-    queue: VecDeque<i32>,
+    push_stack: Vec<i32>,
+    pop_stack: Vec<i32>,
 }
 
 /**
@@ -11,24 +10,39 @@ struct MyQueue {
 impl MyQueue {
     fn new() -> Self {
         MyQueue {
-            queue: VecDeque::new(),
+            push_stack: Vec::new(),
+            pop_stack: Vec::new(),
         }
     }
 
     fn push(&mut self, x: i32) {
-        self.queue.push_front(x);
+        self.push_stack.push(x);
     }
-
     fn pop(&mut self) -> i32 {
-        self.queue.pop_back().unwrap()
+        if self.pop_stack.is_empty() {
+            while let Some(x) = self.push_stack.pop() {
+                self.pop_stack.push(x);
+            }
+        }
+        self.pop_stack.pop().unwrap()
     }
 
     fn peek(&self) -> i32 {
-        self.queue.back().unwrap().clone()
+        if !self.pop_stack.is_empty() {
+            self.pop_stack[self.pop_stack.len() - 1]
+        } else {
+            self.push_stack[0]
+        }
     }
 
     fn empty(&self) -> bool {
-        self.queue.is_empty()
+        if !self.pop_stack.is_empty() {
+            false
+        } else if !self.push_stack.is_empty() {
+            false
+        } else {
+            true
+        }
     }
 }
 

--- a/implement-queue-using-stacks/src/lib.rs
+++ b/implement-queue-using-stacks/src/lib.rs
@@ -1,0 +1,58 @@
+use std::collections::VecDeque;
+
+struct MyQueue {
+    queue: VecDeque<i32>,
+}
+
+/**
+ * `&self` means the method takes an immutable reference.
+ * If you need a mutable reference, change it to `&mut self` instead.
+ */
+impl MyQueue {
+    fn new() -> Self {
+        MyQueue {
+            queue: VecDeque::new(),
+        }
+    }
+
+    fn push(&mut self, x: i32) {
+        self.queue.push_front(x);
+    }
+
+    fn pop(&mut self) -> i32 {
+        self.queue.pop_back().unwrap()
+    }
+
+    fn peek(&self) -> i32 {
+        self.queue.back().unwrap().clone()
+    }
+
+    fn empty(&self) -> bool {
+        self.queue.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_my_queue() {
+        let mut queue = MyQueue::new();
+
+        queue.push(1);
+        queue.push(2);
+        assert_eq!(queue.peek(), 1);
+        assert_eq!(queue.pop(), 1);
+        assert_eq!(queue.empty(), false);
+
+        queue.push(3);
+        assert_eq!(queue.peek(), 2);
+        assert_eq!(queue.pop(), 2);
+        assert_eq!(queue.empty(), false);
+
+        assert_eq!(queue.peek(), 3);
+        assert_eq!(queue.pop(), 3);
+        assert_eq!(queue.empty(), true);
+    }
+}

--- a/implement-queue-using-stacks/src/lib.rs
+++ b/implement-queue-using-stacks/src/lib.rs
@@ -31,18 +31,12 @@ impl MyQueue {
         if !self.pop_stack.is_empty() {
             self.pop_stack[self.pop_stack.len() - 1]
         } else {
-            self.push_stack[0]
+            *self.push_stack.first().unwrap()
         }
     }
 
     fn empty(&self) -> bool {
-        if !self.pop_stack.is_empty() {
-            false
-        } else if !self.push_stack.is_empty() {
-            false
-        } else {
-            true
-        }
+        self.pop_stack.is_empty() && self.push_stack.is_empty()
     }
 }
 


### PR DESCRIPTION
Implement a first in first out (FIFO) queue using only two stacks. The implemented queue should support all the functions of a normal queue (push, peek, pop, and empty).

Implement the `MyQueue` class with the following methods:

- `void push(int x)`: Pushes element x to the back of the queue.
- `int pop()`: Removes the element from the front of the queue and returns it.
- `int peek()`: Returns the element at the front of the queue.
- `boolean empty()`: Returns true if the queue is empty, false otherwise.

**Notes:**
- You must use only standard operations of a stack, which means only push to top, peek/pop from top, size, and is empty operations are valid.
- Depending on your language, the stack may not be supported natively. You may simulate a stack using a list or deque (double-ended queue) as long as you use only a stack's standard operations.