### PR TITLE
Implement MinStack with constant time minimum element retrieval

### DIFF
--- a/min-stack/Cargo.toml
+++ b/min-stack/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "min-stack"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/min-stack/src/lib.rs
+++ b/min-stack/src/lib.rs
@@ -1,0 +1,70 @@
+struct MinStack {
+    stack: Vec<i32>,
+    min_stack: Vec<i32>,
+}
+
+/**
+ * `&self` means the method takes an immutable reference.
+ * If you need a mutable reference, change it to `&mut self` instead.
+ */
+impl MinStack {
+    fn new() -> Self {
+        Self {
+            stack: Vec::new(),
+            min_stack: Vec::new(),
+        }
+    }
+
+    fn push(&mut self, val: i32) {
+        if self.min_stack.is_empty() {
+            self.min_stack.push(val);
+        } else {
+            if self.min_stack[self.min_stack.len() - 1] >= val {
+                self.min_stack.push(val);
+            }
+        }
+        self.stack.push(val);
+    }
+
+    fn pop(&mut self) {
+        let element = self.stack.pop().unwrap();
+        if self.min_stack[self.min_stack.len() - 1] == element {
+            self.min_stack.pop();
+        }
+    }
+
+    fn top(&self) -> i32 {
+        self.stack[self.stack.len() - 1]
+    }
+
+    fn get_min(&self) -> i32 {
+        self.min_stack[self.min_stack.len() - 1]
+    }
+}
+
+/**
+ * Your MinStack object will be instantiated and called as such:
+ * let obj = MinStack::new();
+ * obj.push(val);
+ * obj.pop();
+ * let ret_3: i32 = obj.top();
+ * let ret_4: i32 = obj.get_min();
+ */
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_min_stack() {
+        let mut min_stack = MinStack::new();
+
+        min_stack.push(-2);
+        min_stack.push(0);
+        min_stack.push(-3);
+        assert_eq!(min_stack.get_min(), -3); // should return -3
+
+        min_stack.pop();
+        assert_eq!(min_stack.top(), 0); // should return 0
+        assert_eq!(min_stack.get_min(), -2); // should return -2
+    }
+}

--- a/min-stack/src/lib.rs
+++ b/min-stack/src/lib.rs
@@ -18,10 +18,8 @@ impl MinStack {
     fn push(&mut self, val: i32) {
         if self.min_stack.is_empty() {
             self.min_stack.push(val);
-        } else {
-            if self.min_stack[self.min_stack.len() - 1] >= val {
-                self.min_stack.push(val);
-            }
+        } else if self.min_stack[self.min_stack.len() - 1] >= val {
+            self.min_stack.push(val);
         }
         self.stack.push(val);
     }


### PR DESCRIPTION
## Description

This pull request introduces a solution for the MinStack problem. The solution consists of two stacks, `stack` and `min_stack`. The `stack` is used for regular stack operations such as push, pop, and top, while `min_stack` is responsible for keeping track of the minimum element at all times.

The `push` operation pushes the element onto the `stack` and also checks if the element being pushed is less than or equal to the current minimum element. If so, it pushes the element onto the `min_stack` as well.

The `pop` operation removes the top element from the `stack`. If the popped element is equal to the current minimum element, it also pops the top element from the `min_stack`.

The `top` operation returns the top element of the `stack`.

The `get_min` operation retrieves the minimum element in constant time by simply returning the top element of the `min_stack`.

This implementation ensures that all functions have O(1) time complexity.
